### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,7 +101,8 @@ def get_stock_data(symbol):
         return jsonify(result)
         
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.exception(f"Exception in get_stock_data for symbol '{symbol}'")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/historical/<symbol>')
 def get_historical_data(symbol):


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/Stock-market/security/code-scanning/2](https://github.com/vannu07/Stock-market/security/code-scanning/2)

The best way to fix this problem is to stop returning the raw exception message to the client. Instead, return a generic error message such as "An internal error has occurred." to the client in all cases. On the server side, log the full exception and stack trace so that developers/admins have complete diagnostic information. You should use Python's logging module for error logging, and capture the stack trace using `logger.exception()` within the except block, which automatically includes traceback information. 

You only need to edit the exception handling blocks in the Flask route handler `/api/stock/<symbol>` (lines 103–104): replace the return value with a generic error message, and call `logger.exception()` to log the details. Only edit what you have been shown. No need to add imports or change logger configuration since `logger` is already set up.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
