### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -112,7 +112,8 @@ def get_historical_data(symbol):
         data = stock_collector.get_historical_data(symbol, days)
         return jsonify(data)
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.exception(f"Exception in get_historical_data for symbol '{symbol}'")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/sentiment/<symbol>')
 def get_sentiment_analysis(symbol):
@@ -121,7 +122,8 @@ def get_sentiment_analysis(symbol):
         sentiment_data = sentiment_collector.get_detailed_sentiment(symbol)
         return jsonify(sentiment_data)
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.exception(f"Exception in get_sentiment_analysis for symbol '{symbol}'")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/predictions/<symbol>')
 def get_predictions(symbol):
@@ -130,7 +132,8 @@ def get_predictions(symbol):
         predictions = ensemble_predictor.get_all_predictions(symbol)
         return jsonify(predictions)
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.exception(f"Exception in get_predictions for symbol '{symbol}'")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/news/<symbol>')
 def get_news(symbol):


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/Stock-market/security/code-scanning/5](https://github.com/vannu07/Stock-market/security/code-scanning/5)

To fix this problem, exception details must not be sent to users. Instead, return a generic error message (such as "An internal error has occurred") and log the full exception on the server using the configured logger. Make this change in all endpoints that currently return `{'error': str(e)}` or similar. Specifically, in app.py lines 115, 124, and 133, replace the current `jsonify({'error': str(e)})` structure with a generic message, and log the full exception details for internal reference. For consistency, ensure each exception handler uses `logger.exception(...)` as in line 104 and line 154, to capture the traceback. Only code lines you've been shown can be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
