### PR TITLE
Potential fix for code scanning alert no. 48: Except block handles 'BaseException'

### DIFF
--- a/backend/data_collectors/news_sentiment_collector.py
+++ b/backend/data_collectors/news_sentiment_collector.py
@@ -21,7 +21,7 @@ try:
     nltk.download("punkt", quiet=True)
     nltk.download("wordnet", quiet=True)
     nltk.download("vader_lexicon", quiet=True)
-except:
+except Exception:
     pass
 
 # Add parent directory to path
@@ -489,14 +489,14 @@ class NewsSentimentCollector:
                 results["news_api"] = response.status_code == 200
             else:
                 results["news_api"] = False
-        except:
+        except Exception:
             results["news_api"] = False
 
         # Test RSS feeds
         try:
             feed = feedparser.parse(self.rss_feeds[0])
             results["rss_feeds"] = len(feed.entries) > 0
-        except:
+        except Exception:
             results["rss_feeds"] = False
 
         return results

--- a/backend/data_collectors/news_sentiment_collector.py
+++ b/backend/data_collectors/news_sentiment_collector.py
@@ -21,8 +21,9 @@ try:
     nltk.download("punkt", quiet=True)
     nltk.download("wordnet", quiet=True)
     nltk.download("vader_lexicon", quiet=True)
-except Exception:
-    pass
+except Exception as e:
+    # NLTK data may already be installed; log the failure and continue.
+    logging.warning("Failed to download some NLTK data resources: %s", e)
 
 # Add parent directory to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/Stock-market/security/code-scanning/48](https://github.com/vannu07/Stock-market/security/code-scanning/48)

In general, the fix is to avoid bare `except:` clauses and avoid catching `BaseException` unless there is a very specific and well‑documented reason. Instead, catch `Exception` for “normal” errors, and only catch `KeyboardInterrupt` or `SystemExit` explicitly if needed, otherwise let them propagate.

For this file, the best fix without changing functionality is:

- Change the bare `except:` around the NLTK downloads to `except Exception:` so that only regular exceptions are suppressed; interrupts and exits will still stop the program.
- Change the bare `except:` in `test_connection` (for both the News API and RSS sections) to `except Exception:` so that unexpected runtime errors cause the corresponding service to be marked as unavailable, but `KeyboardInterrupt`/`SystemExit` will propagate as intended.

No new imports or helper methods are needed. All changes are within `backend/data_collectors/news_sentiment_collector.py` at the shown `try/except` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes code-scanning alert #48 by replacing bare `except:` blocks with more specific `except Exception:` exception handlers in the news sentiment collector module.

### Changes

**File modified:** `backend/data_collectors/news_sentiment_collector.py`

The PR updates exception handling in two areas:

1. **NLTK download section**: Changed bare `except:` to `except Exception:` to properly log warnings when NLTK downloads fail, while allowing system-level interrupts (like KeyboardInterrupt) to propagate normally.

2. **Test connection method**: Updated error handling in both News API and RSS sections from bare `except:` to `except Exception:` so that runtime errors mark services as unavailable without suppressing system exit signals.

### Why it matters

Bare `except:` blocks catch all exceptions including `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`, which can prevent proper program shutdown. This change allows the application to gracefully handle user interrupts and system exits while still catching regular runtime errors.

### Impact

- More robust error handling that respects system-level signals
- Maintains existing behavior (logging warnings, marking service failures) while improving control flow
- Minimal changes: 5 lines added, 4 lines removed
- No new dependencies or helper functions required

The fix was auto-generated by Copilot and should be reviewed for alignment with project coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->